### PR TITLE
Feature: Implements GitHub Notifications Management Functionality

### DIFF
--- a/src/github/gh-notification-delete.sh
+++ b/src/github/gh-notification-delete.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This section loads configuration files needed to set environment variables
+# such as GITHUB_TOKEN. If these variables are already exported globally in the shell, 
+# the files below can remain commented out. Otherwise, uncomment the appropriate 
+# file(s) as needed. This particular script only needs GITHUB_TOKEN to function properly.
+
+# source "$GITNAP/utils/auth.sh"
+# source "$GITNAP/utils/settings.sh"
+
+
+
+function delete_github_notifications() {
+	local NOTIFICATION_ID
+    local endpoint
+    local response
+    local tmp_file
+    
+    NOTIFICATION_ID="$1"
+
+    # Checks if the parameter was provided.
+    if [[ -z "$NOTIFICATION_ID" ]]; then
+        echo "Provide id notification to delete"
+        exit 1
+    fi
+    
+    # API Endpoint
+    endpoint="https://api.github.com/notifications/threads/$NOTIFICATION_ID"
+
+    # Delete notifications
+    response=$(curl -sSL -X DELETE "$endpoint" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" )
+
+    echo "$response" 
+
+}
+
+delete_github_notifications "$1"

--- a/src/github/gh-notification-list.sh
+++ b/src/github/gh-notification-list.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This section loads configuration files needed to set environment variables
+# such as GITHUB_TOKEN. If these variables are already exported globally in the shell, 
+# the files below can remain commented out. Otherwise, uncomment the appropriate 
+# file(s) as needed. This particular script only needs GITHUB_TOKEN to function properly.
+
+# source "$GITNAP/utils/auth.sh"
+# source "$GITNAP/utils/settings.sh"
+
+
+
+function list_github_notifications() {
+    local endpoint
+    local response
+    local tmp_file
+
+    # API Endpoint
+    endpoint="https://api.github.com/notifications"
+
+    # Get notifications
+    response=$(curl -sSL "$endpoint" \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" )
+    
+    # See in terminal
+    tmp_file=$(mktemp)
+    echo "$response" > "$tmp_file"
+    less "$tmp_file"
+    rm "$tmp_file"
+
+}
+
+list_github_notifications


### PR DESCRIPTION
This pull request introduces two new functions, **`gh-notifications-list.sh`** and **`gh-notifications-delete.sh`**, to allow authenticated users to view and manage their GitHub notifications directly within the tool. These utilities utilize the GitHub API to fetch and modify notification data.

---

### Scripts Implemented:

* **`gh-notifications-list.sh`**: This function retrieves and displays the authenticated user's current GitHub notifications. It interacts with the GitHub API (`api.github.com/notifications`), stores the JSON response in a temporary file, and presents the list to the user in the terminal using `less` for easy navigation. This is analogous to the `gh-repo-list.sh` implementation.

* **`gh-notifications-delete.sh`**: This function allows the user to delete (mark as read/done) a specific GitHub notification thread. It accepts the notification thread ID as a required argument and sends a `DELETE` request to the GitHub API (`api.github.com/notifications/threads/{thread_id}`) to dismiss the notification.

---

### Motivation:

This enhancement provides users with a convenient command-line interface to keep track of and manage their GitHub activity without leaving the terminal environment.

* **Efficiency**: Users can quickly check for new activity and clear out notifications without switching contexts to a web browser.
* **Automation Building Block**: The functions serve as foundational tools for future scripting and automation, such as creating routines to process or archive specific types of notifications programmatically.